### PR TITLE
Update with a few more rules, remove usage rules

### DIFF
--- a/lib/equality.js
+++ b/lib/equality.js
@@ -139,7 +139,7 @@ function join(value, joiner) {
 function message(violation, suggestion, joiner, note) {
 
     return join(quotation(violation, '`'), joiner) +
-        ' violates Shopify style ' + '(' + note + ').' + ' Use ' +
+        ' is not Shopify style ' + '(' + note + ').' + ' Use ' +
         join(quotation(suggestion, '`'), joiner) +
         '.';
 }

--- a/lib/patterns.json
+++ b/lib/patterns.json
@@ -84,53 +84,6 @@
     "note": "avoid unnecessarily wordy phrases"
   },
   {
-    "id": "comprised-of",
-    "type": "simple",
-    "categories": [
-      "a"
-    ],
-    "correct": {
-      "comprises": "a",
-      "composed of": "a"
-    },
-    "incorrect": {
-      "comprised of": "a"
-    },
-    "note": "strictly, 'comprise' just means 'include'"
-  },
-  {
-    "id": "utilize",
-    "type": "simple",
-    "categories": [
-      "a"
-    ],
-    "correct": {
-      "use": "a"
-    },
-    "incorrect": {
-      "utilize": "a"
-    },
-    "note": "utilize just means 'use'"
-  },
-  {
-    "id": "could-of",
-    "type": "simple",
-    "categories": [
-      "a"
-    ],
-    "correct": {
-      "could have": "a",
-      "should have": "a",
-      "would have": "a"
-    },
-    "incorrect": {
-      "could of": "a",
-      "should of": "a",
-      "would of": "a"
-    },
-    "note": "use 'have', not 'of'"
-  },
-  {
     "id": "eg.",
     "type": "simple",
     "categories": [
@@ -144,7 +97,7 @@
       "e.g.": "a",
       "eg.": "a"
     },
-    "note": "avoid latin abbreviations"
+    "note": "avoid Latin abbreviations"
   },
   {
     "id": "ie.",
@@ -159,7 +112,7 @@
       "i.e.": "a",
       "ie.": "a"
     },
-    "note": "avoid latin abbreviations"
+    "note": "avoid Latin abbreviations"
   },
   {
     "id": "via",
@@ -168,12 +121,13 @@
       "a"
     ],
     "correct": {
-      "by": "a"
+      "by": "a",
+      "with": "a"
     },
     "incorrect": {
       "via": "a"
     },
-    "note": "avoid latin abbreviations"
+    "note": "avoid Latin words"
   },
   {
     "id": "help-centre",
@@ -293,6 +247,34 @@
     "note": "be direct and not apologetic"
   },
   {
+    "id": "sorry",
+    "type": "simple",
+    "categories": [
+      "a"
+    ],
+    "correct": {
+      "(don’t say sorry)": "a"
+    },
+    "incorrect": {
+      "sorry": "a"
+    },
+    "note": "be direct and not apologetic"
+  },
+  {
+    "id": "oops",
+    "type": "simple",
+    "categories": [
+      "a"
+    ],
+    "correct": {
+      "(don’t say oops)": "a"
+    },
+    "incorrect": {
+      "oops": "a"
+    },
+    "note": "be direct and not apologetic"
+  },
+  {
     "id": "input",
     "type": "simple",
     "categories": [
@@ -365,5 +347,21 @@
       "may": "a"
     },
     "note": "use controlled vocabulary"
+  },
+  {
+    "id": "once-the",
+    "type": "simple",
+    "categories": [
+      "a"
+    ],
+    "correct": {
+      "when": "a",
+      "after": "a"
+    },
+    "incorrect": {
+      "once the": "a",
+      "once you": "a"
+    },
+    "note": "don't say \"once\" if you mean \"when\""
   }
 ]

--- a/script/content.yml
+++ b/script/content.yml
@@ -45,27 +45,7 @@
 
 ## Commonly misused words/phrases
 - type: simple
-  note: strictly, 'comprise' just means 'include'
-  incorrect: comprised of
-  correct:
-    - comprises
-    - composed of
-- type: simple
-  note: utilize just means 'use'
-  incorrect: utilize
-  correct: use
-- type: simple
-  note: use 'have', not 'of'
-  incorrect:
-    - could of
-    - should of
-    - would of
-  correct:
-    - could have
-    - should have
-    - would have
-- type: simple
-  note: avoid latin abbreviations
+  note: avoid Latin abbreviations
   incorrect:
     - e.g.
     - eg.
@@ -73,26 +53,18 @@
     - for example
     - like
 - type: simple
-  note: avoid latin abbreviations
+  note: avoid Latin abbreviations
   incorrect:
     - i.e.
     - ie.
   correct:
     - that is
 - type: simple
-  note: avoid latin abbreviations
+  note: avoid Latin words
   incorrect: via
   correct:
     - by
-
-
-# - type: simple
-#   note: instead of using 'etc', just list other things worth mentioning.
-#   incorrect:
-#     - etc
-#     - etc.
-#     - etcetera
-#   correct:
+    - with
 
 # BRANDING
 - type: simple
@@ -115,8 +87,6 @@
   incorrect:
     - Shopify administrative panel
     - Shopify dashboard
-
-
 
 # AMERICAN SPELLINGS
 - type: simple
@@ -141,6 +111,14 @@
   note: be direct and not apologetic
   correct: (don’t say unfortunately)
   incorrect: unfortunately
+- type: simple
+  note: be direct and not apologetic
+  correct: (don’t say sorry)
+  incorrect: sorry
+- type: simple
+  note: be direct and not apologetic
+  correct: (don’t say oops)
+  incorrect: oops
 
 # DOCS SG
 - type: simple
@@ -171,3 +149,11 @@
   correct: might
   incorrect:
     - may
+- type: simple
+  note: don't say "once" if you mean "when"
+  correct:
+    - when
+    - after
+  incorrect:
+    - once the
+    - once you


### PR DESCRIPTION
I removed the English usage rules (which should now go in [retext-usage](https://github.com/admhlt/retext-usage)) and tidied up the word list a little, adding a few more rules on apologetic language and using "once" to mean "when" (one of my biggest pet peeves).

cc @jeremyhansonfinger @zakkain 
