### PR TITLE
Add dashes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@ components/
 coverage/
 retext-equality.js
 retext-equality.min.js
+retext-simplify.js
+retext-simplify.min.js

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 coverage/
 retext-equality.js
 retext-equality.min.js
+retext-simplify.js
+retext-simplify.min.js

--- a/.jscs.json
+++ b/.jscs.json
@@ -4,7 +4,9 @@
     "coverage/",
     "node_modules/",
     "retext-equality.js",
-    "retext-equality.min.js"
+    "retext-equality.min.js",
+    "retext-simplify.js",
+    "retext-simplify.min.js"
   ],
   "preset": "yandex",
   "requireQuotedKeysInObjects": true,

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,12 +1,14 @@
 {
   "output": true,
-  "plugins": [
-    "lint",
-    "github",
-    "comment-config",
-    "slug",
-    "validate-links"
-  ],
+  "plugins": {
+    "lint": {
+      "code-block-style": "fenced"
+    },
+    "github": {},
+    "comment-config": {},
+    "slug": {},
+    "validate-links": {}
+  },
   "settings": {
     "bullet": "*"
   }

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,19 @@
-Copyright (c) 2016 Shopify <docsteam@shopify.com>
+Copyright (c) 2016 Shopify <mailto:docsteam@shopify.com>
 
-Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
 
-Contains code adapted from [retext-simplify](https://github.com/wooorm/retext-simplify) by Titus Wormer under MIT license, and [retext-mapbox-standard](https://github.com/mapbox/retext-mapbox-standard) by Mapbox under ISC license.
+Contains code adapted from
+[retext-simplify](https://github.com/wooorm/retext-simplify) by Titus Wormer
+under MIT license, and
+[retext-mapbox-standard](https://github.com/mapbox/retext-mapbox-standard) by
+Mapbox under ISC license.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,16 +1,21 @@
 Copyright (c) 2016 Shopify <mailto:docsteam@shopify.com>
 
-Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Contains code adapted from
 [retext-simplify](https://github.com/wooorm/retext-simplify) by Titus Wormer

--- a/index.js
+++ b/index.js
@@ -84,9 +84,9 @@ var list = keys(patterns);
 
             message.ruleId = phrase;
             message.source = 'retext-shopify';
-            });
             }
 
+        }, {'allowApostrophes': false, 'allowDashes': true});
 
     return transformer;
 }

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ var list = keys(patterns);
  *   - List of phrases to *not* warn about.
  * @return {Function} - `transformer`.
  */
-    function attacher(processor, options) {
+
+function attacher(processor, options) {
     var ignore = (options || {}).ignore || [];
     var phrases = difference(list, ignore);
 
@@ -59,34 +60,32 @@ var list = keys(patterns);
             var message = undefined;
 
             if (!replace.length) {
-                message = value + " is not Shopify style. Avoid using it.";
+                message = value + ' is not Shopify style. Avoid using it.';
 
-                  if (note)
-                      message += " (" + note + ")"
-           }
-            
-            else if (matchedString !== replace){
-                message = value + " is not Shopify style. Use " + newvalue + " instead.";
+                if (note) {
+                    message += ' (' + note + ')';
+                }
+            } else if (matchedString !== replace){
+                message = value + ' is not Shopify style. Use ' + newvalue +
+                    ' instead.';
 
-                  if (note)
-                      message += " (" + note + ")"
+                if (note) {
+                    message += ' (' + note + ')';
+                }
+            } else if (matchedString === replace){
+                return transformer;
             }
 
-            else if (matchedString === replace){
-              return transformer
-            }         
-         
-           if (message)
-            message = file.warn(message, {
-                'start': match[0].position.start,
-                'end': match[match.length - 1].position.end
-            });
-
+            if (message) {
+                message = file.warn(message, {
+                    'start': match[0].position.start,
+                    'end': match[match.length - 1].position.end
+                });
+            }
             message.ruleId = phrase;
             message.source = 'retext-shopify';
-            }
-
         }, {'allowApostrophes': false, 'allowDashes': true});
+    }
 
     return transformer;
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Titus Wormer <tituswormer@gmail.com> (http://wooorm.com)",
   "dependencies": {
     "array-differ": "^1.0.0",
-    "nlcst-search": "^1.0.0",
+    "nlcst-search": "../nlcst-search",
     "nlcst-to-string": "^1.1.0",
     "object-keys": "^1.0.9",
     "quotation": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Titus Wormer <tituswormer@gmail.com> (http://wooorm.com)",
   "dependencies": {
     "array-differ": "^1.0.0",
-    "nlcst-search": "../nlcst-search",
+    "nlcst-search": "^1.3.0",
     "nlcst-to-string": "^1.1.0",
     "object-keys": "^1.0.9",
     "quotation": "^1.0.0"

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,19 @@
 # Retext-shopify
 
-Warn about Shopify style guide violations with [**retext**](https://github.com/wooorm/retext).
+Warn about Shopify style guide violations with
+[**retext**](https://github.com/wooorm/retext).
 
-**Retext-shopify** is a ruleset for [**rorybot**](https://github.com/Shopify/rorybot), a command-line linter that can be added into your text editor. See [**linter-rorybot**](https://github.com/Shopify/linter-rorybot) if you use Atom or [**sublimelinter-rorybot**](https://github.com/Shopify/sublimelinter-rorybot) if you use Sublime Text. 
+**Retext-shopify** is a ruleset for
+[**rorybot**](https://github.com/Shopify/rorybot), a command-line linter that
+can be added into your text editor. See
+[**linter-rorybot**](https://github.com/Shopify/linter-rorybot) if you use Atom
+or [**sublimelinter-rorybot**](https://github.com/Shopify/sublimelinter-rorybot)
+if you use Sublime Text.
 
 ## Installing and updating
 
-This package is automatically installed and updated as a dependency of [**rorybot**](https://github.com/Shopify/rorybot).
+This package is automatically installed and updated as a dependency of
+[**rorybot**](https://github.com/Shopify/rorybot).
 
 ## Contributing
 
@@ -14,40 +21,43 @@ Content rules are written in `data/index.json`.
 
 ### Content rules
 
-The rule set is a list of simple phrase matches written in JSON with the following format:
+The rule set is a list of simple phrase matches written in JSON with the
+following format:
 
-```
-  "[incorrect phrase]": {
-    "note": "[reason for the warning]",
-    "replace": "[replacement phrase(s)]"
-  },
-
+```json
+"[incorrect phrase]": {
+  "note": "[reason for the warning]",
+  "replace": "[replacement phrase(s)]"
+},
 ```
 
 For example:
 
-```
-  "customise": {
-    "replace": "customize",
-    "note": "Use American spelling."  
-  },
+```json
+"customise": {
+  "replace": "customize",
+  "note": "Use American spelling."
+},
 ```
 
 This rule would flag the phrase `Customise` with the following message:
 
-```
+```bash
 <stdin>
-  9:17-9:26  warning  “Customise” is not Shopify style. 
+  9:17-9:26  warning  “Customise” is not Shopify style.
     Use “customize” instead. (Use American spelling.)
 ```
 
 ### Note guidelines
 
-When you enter the `note`, use a short, imperative sentence explaining the warning. Be sure to capitalize and add punctuation at the end.
+When you enter the `note`, use a short, imperative sentence explaining the
+warning. Be sure to capitalize and add punctuation at the end.
 
 #### No replacement
 
-If you don't define a replacement, just put two square brackets (`[]`) before the comma instead. When **rorybot** runs it will tell you to avoid using that term and print the explanatory note.
+If you don't define a replacement, just put two square brackets (`[]`) before
+the comma instead. When **rorybot** runs it will tell you to avoid using that
+term and print the explanatory note.
 
 For example:
 
@@ -60,15 +70,17 @@ For example:
 
 This rule would flag the phrase `Oops` with the following message:
 
-```
+```bash
 <stdin>
-  9:1-9:5  warning  “Oops” is not Shopify style. 
+  9:1-9:5  warning  “Oops” is not Shopify style.
     Avoid using it. (Just don't.)
 ```
 
 #### Multiple replacements
 
-If you want **rorybot** to suggest multiple possible replacements for an incorrect phrase, separate the replacement phrases with a comma and place them within square brackets, like this:
+If you want **rorybot** to suggest multiple possible replacements for an
+incorrect phrase, separate the replacement phrases with a comma and place them
+within square brackets, like this:
 
 ```json
     "e.g.": {
@@ -77,17 +89,20 @@ If you want **rorybot** to suggest multiple possible replacements for an incorre
   },
 ```
 
-```
+```bash
 <stdin>
-  8:26-8:30  warning  “e.g.” is not Shopify style. 
+  8:26-8:30  warning  “e.g.” is not Shopify style.
     Use “like”,“for example” instead. (Avoid Latin abbreviations.)
 ```
 
 ##### Capitalization
 
-Enter the incorrect phrase as lowercase, but use the correct casing for the replacement phrase. The linter will flag any matching string if it doesn't have the same casing as the replacement phrase.
+Enter the incorrect phrase as lowercase, but use the correct casing for the
+replacement phrase. The linter will flag any matching string if it doesn't have
+the same casing as the replacement phrase.
 
-If `Shopify POS` and `Unlimited plan` are the only ways you want to style these two phrases, the rules would look like this:
+If `Shopify POS` and `Unlimited plan` are the only ways you want to style these
+two phrases, the rules would look like this:
 
 ```json
   "shopify point of sale": {
@@ -98,16 +113,18 @@ If `Shopify POS` and `Unlimited plan` are the only ways you want to style these 
     "note": "Incorrect capitalization.",
     "replace": "Unlimited plan"
   },
-
 ```
 
-For instance, based on the above rules, if you ran **rorybot** on a document containing the phrases `unlimited Plan`, `UnLimited plan`, `Shopify point of sale`, `shopify point of sale`, you'd get the following warnings:
+For instance, based on the above rules, if you ran **rorybot** on a document
+containing the phrases `unlimited Plan`, `UnLimited plan`,
+`Shopify point of sale`, `shopify point of sale`, you'd get the following
+warnings:
 
-```
+```bash
 <stdin>
-  3:20-3:34  warning  “unlimited Plan” is not Shopify style. 
+  3:20-3:34  warning  “unlimited Plan” is not Shopify style.
     Use “Unlimited plan” instead. (Incorrect capitalization.)
-  5:20-5:34  warning  “UnLimited plan” is not Shopify style. 
+  5:20-5:34  warning  “UnLimited plan” is not Shopify style.
     Use “Unlimited plan” instead. (Incorrect capitalization.)
   6:8-6:29  warning  “Shopify point of sale” is not Shopify style.
     Use “Shopify POS” instead. (Incorrect branded name.)
@@ -117,40 +134,61 @@ For instance, based on the above rules, if you ran **rorybot** on a document con
 
 ### Updating rules
 
-1. Clone this repo to your local machine and `cd` into its folder.
-2. Create a branch for your changes (`git checkout -b your-branch-name`).
-2. Open `data/index.json` in a text editor.
-3. Make your changes to the rule list.
-4. Save `index.json`.
-5. Test your rules (see _Testing rules_).
-6. Commit your changes (`git commit -am "Your commit message"`). The changed files should be `index.json` and `test.js`.
-6. Run `git push origin your-branch-name` to create a pull request with your changes.
+1.  Clone this repo to your local machine and `cd` into its folder.
+
+2.  Create a branch for your changes (`git checkout -b your-branch-name`).
+
+3.  Open `data/index.json` in a text editor.
+
+4.  Make your changes to the rule list.
+
+5.  Save `index.json`.
+
+6.  Test your rules (see _Testing rules_).
+
+7.  Commit your changes (`git commit -am "Your commit message"`). The changed
+    files should be `index.json` and `test.js`.
+
+8.  Run `git push origin your-branch-name` to create a pull request with your
+    changes.
 
 ### Testing rules
 
-1. `cd` into your local copy of the repo.
-2. Open `test.js` in a text editor. 
-3. Add the strings you want to test to the list, in single quotes and separated by commas:
-```js
-retext()
-    .use(shopify)
-    .process([
-        'I love using Liquid.',
-        'I love using liquid.',
-        'I\'m on the Shopify unlimited Plan',
-        'I\'m on the Shopify Unlimited plan',
-        'I\'m on the Shopify UnLimited plan',
-        'Check out Shopify point of sale',
-        'Check out shopify point of sale',
-        '!'
-    ].join('\n'), function (err, file) {
-        console.log(report(file));
-    });
+1.  `cd` into your local copy of the repo.
 
-```
-4. Save `test.js`.
-4. In your terminal, run `node test.js` to see the results of running **rorybot** on those strings using the **retext-shopify** library. If you want to output the result to a file in the same directory, run `node test.js | tee output.txt` (but you can call `output.txt` whatever you want). 
-5. Check your JSON in a [JSON validator](http://jsonlint.com/) if you run into issues.
+2.  Open `test.js` in a text editor.
 
-In the future we'll define more rules about when and where to add test strings, but for now before you commit and push to your remote branch, save `test.js` with whatever test strings you think are important. 
+3.  Add the strings you want to test to the list, in single quotes and separated
+    by commas:
 
+    ```js
+    retext()
+        .use(shopify)
+        .process([
+            'I love using Liquid.',
+            'I love using liquid.',
+            'I\'m on the Shopify unlimited Plan',
+            'I\'m on the Shopify Unlimited plan',
+            'I\'m on the Shopify UnLimited plan',
+            'Check out Shopify point of sale',
+            'Check out shopify point of sale',
+            '!'
+        ].join('\n'), function (err, file) {
+            console.log(report(file));
+        });
+    ```
+
+4.  Save `test.js`.
+
+5.  In your terminal, run `node test.js` to see the results of running
+    **rorybot** on those strings using the **retext-shopify** library. If you
+    want to output the result to a file in the same directory, run
+    `node test.js | tee output.txt` (but you can call `output.txt` whatever you
+    want).
+
+6.  Check your JSON in a [JSON validator](http://jsonlint.com/) if you run
+    into issues.
+
+In the future we'll define more rules about when and where to add test
+strings, but for now before you commit and push to your remote branch, save
+`test.js` with whatever test strings you think are important.

--- a/test.js
+++ b/test.js
@@ -1,21 +1,271 @@
+/* eslint-env node */
+
 var retext = require('retext');
 var shopify = require('./index');
-var report = require('vfile-reporter');
+var test = require('tape');
 
-retext()
-    .use(shopify)
-    .process([
-        'I love using Liquid once the.',
-        'I love using liquid.',
-        'I\'m on the Shopify unlimited Plan',
-        'I\'m on the Shopify Unlimited plan',
-        'I\'m on the Shopify UnLimited plan',
-        'Check out the drop-down menu in Shopify point of sale',
-        'I love the dropdown menu in shopify point of sale',
-        'I love the drop down menu',
-        'Unfortunately, I need to close down, i.e., customise my drink',
-        'Oops, I need to Customise my drink with the shopify manual',
-        '!'
-    ].join('\n'), function (err, file) {
-        console.log(report(file));
+var output = {};
+
+/**
+ * process.
+ *
+ * @param {string} str - string to process
+ * @return {Object} - results
+ */
+
+function process(str) {
+    output = {};
+    retext().use(shopify).process(str, function (err, file) {
+        output = file;
     });
+    return output;
+}
+
+test('once the', function (t) {
+    var actual;
+
+    t.plan(3);
+
+    actual = process('I love using Liquid once the.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'once the',
+        '“once the” violates ruleId “once the”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('I love using Liquid when.');
+    t.equal(actual.messages.length, 0, '“when” is ok');
+});
+
+test('unlimited plan', function (t) {
+    var actual;
+
+    t.plan(5);
+
+    actual = process('I’m on the Shopify unlimited Plan');
+    t.equal(
+        actual.messages[0].ruleId,
+        'unlimited plan',
+        '“unlimited Plan” violates ruleId “unlimited plan”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('I’m on the Shopify UnLimited plan');
+    t.equal(
+        actual.messages[0].ruleId,
+        'unlimited plan',
+        '“UnLimited plan” violates ruleId “unlimited plan”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('I’m on the Shopify Unlimited plan');
+    t.equal(
+        actual.messages.length, 0,
+        '“Unlimited plan” is ok'
+    );
+});
+
+test('drop-down menu', function (t) {
+    var actual;
+
+    t.plan(5);
+
+    actual = process('I love the dropdown menu.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'dropdown menu',
+        '“dropdown menu” violates ruleId “drop down menu”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('I love the drop down menu.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'drop down menu',
+        '“drop down menu” violates ruleId “drop down menu”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('I love the drop-down menu.');
+    t.equal(
+        actual.messages.length, 0,
+        '“drop-down menu” is ok'
+    );
+});
+
+test('shopify pos', function (t) {
+    var actual;
+
+    t.plan(3);
+
+    actual = process('I love Shopify point of sale.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'shopify point of sale',
+        '“Shopify point of sale” violates ruleId “shopify point of sale”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('I love Shopify POS.');
+    t.equal(
+        actual.messages.length, 0,
+        '“Shopify POS” is ok'
+    );
+});
+
+test('unfortunately', function (t) {
+    var actual;
+
+    t.plan(2);
+
+    actual = process('Unfortunately, an error occurred.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'unfortunately',
+        '“Unfortunately” violates ruleId “unfortunately”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+});
+
+test('oops', function (t) {
+    var actual;
+
+    t.plan(2);
+
+    actual = process('Oops, an error occurred.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'oops',
+        '“Oops” violates ruleId “oops”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+});
+
+test('close down', function (t) {
+    var actual;
+
+    t.plan(3);
+
+    actual = process('I need to close down my shop.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'close down',
+        '“close down” violates ruleId “close down”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('I need to close my shop.');
+    t.equal(
+        actual.messages.length, 0,
+        '“close” is ok'
+    );
+});
+
+test('customise', function (t) {
+    var actual;
+
+    t.plan(3);
+
+    actual = process('I’d like to customise my drink.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'customise',
+        '“customise” violates ruleId “customise”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('I’d like to customize my drink.');
+    t.equal(
+        actual.messages.length, 0,
+        '“customize” is ok'
+    );
+});
+
+test('shopify help center', function (t) {
+    var actual;
+
+    t.plan(7);
+
+    actual = process('Go to the Shopify manual.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'shopify manual',
+        '“Shopify manual” violates ruleId “shopify manual”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('Go to the Shopify docs.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'shopify docs',
+        '“Shopify docs” violates ruleId “shopify docs”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('Go to the Shopify Help Centre.');
+    t.equal(
+        actual.messages[0].ruleId,
+        'help centre',
+        '“Shopify Help Centre” violates ruleId “help centre”'
+    );
+    t.equal(
+        actual.messages[0].source,
+        'retext-shopify',
+        'source is “retext-shopify”'
+    );
+
+    actual = process('Go to the Shopify Help Center.');
+    t.equal(
+        actual.messages.length, 0,
+        '“Shopify Help Center” is ok'
+    );
+});


### PR DESCRIPTION
@jeremyhansonfinger I had to add a million tests to figure out what was wrong; I figure it doesn’t hurt to keep them in.

Issue in this repo was that we were’t calling `search` properly — you can’t actually pass in `false, true` because there’s only one argument -- `options`. If `options` is a boolean it sets `allowApostrophes`. We need it to be an object where we explicitly set `allowApostrophes` and `allowDashes`.