### PR TITLE
Add Timeline caps rule

### DIFF
--- a/data/index.json
+++ b/data/index.json
@@ -161,6 +161,6 @@
   },
   "timeline": {
     "replace": ["Timeline"],
-    "note": "Timeline is capitalized."
+    "note": "Timeline is capitalized when referring to the feature in Shopify admin."
   }
 }


### PR DESCRIPTION
Add to rorybot: Timeline is capitalized when referring to the feature in Shopify admin.

@geneshannon @jeremyhansonfinger 
